### PR TITLE
Potential fix for code scanning alert no. 16: Server-side request forgery

### DIFF
--- a/src/main/java/com/microfocus/example/web/controllers/UserController.java
+++ b/src/main/java/com/microfocus/example/web/controllers/UserController.java
@@ -59,6 +59,8 @@ import javax.validation.Valid;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLConnection;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -82,9 +84,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -611,12 +616,45 @@ public class UserController extends AbstractBaseController {
         return ResponseEntity.notFound().build();
     }
     
+    private static final Set<String> SSRF_ALLOWED_HOSTS = new HashSet<>(
+            Arrays.asList("example.com", "www.example.com"));
+
+    private boolean isAllowedUrl(String rawUrl) {
+        try {
+            URI uri = new URI(rawUrl);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+
+            if (Objects.isNull(scheme) || Objects.isNull(host)) {
+                return false;
+            }
+
+            if (!("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
+                return false;
+            }
+
+            // Disallow credentialed URLs
+            if (Objects.nonNull(uri.getUserInfo())) {
+                return false;
+            }
+
+            return SSRF_ALLOWED_HOSTS.contains(host.toLowerCase());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
     @GetMapping("/ssrf")
     public String ssrfExploit(Model model, @Param("url") String url) {
     	
     	if (Objects.isNull(url) || url.isEmpty())
     		return "user/ssrf";
-    	
+
+        if (!isAllowedUrl(url)) {
+            model.addAttribute("url", url);
+            model.addAttribute("urlcontent", "URL is not allowed.");
+            return "user/ssrf";
+        }
     	
     	URL urlLoc;
 		try {


### PR DESCRIPTION
Potential fix for [https://github.com/psidevsecos/IWA-Java/security/code-scanning/16](https://github.com/psidevsecos/IWA-Java/security/code-scanning/16)

To fix SSRF safely without changing core functionality, validate and constrain user-supplied URLs before issuing requests. The best approach here is to parse with `URI`, require `http/https`, reject user-info, and enforce an allowlist of permitted hosts (or exact URLs). Then only open the connection if validation passes.

In `src/main/java/com/microfocus/example/web/controllers/UserController.java`, update `ssrfExploit` so that:
- It validates the incoming `url` using a helper method.
- On invalid URL, return the same view with an error message instead of fetching.
- On valid URL, proceed with the existing fetch/read behavior.

Also add:
- `java.net.URI` and `java.net.URISyntaxException` imports.
- A private static allowlist of hostnames.
- A private helper method `isAllowedUrl(String rawUrl)` that performs the checks.

This keeps endpoint behavior (fetching external content into `urlcontent`) while preventing arbitrary internal/network target access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
